### PR TITLE
Fix race condition leading to crashes

### DIFF
--- a/SelectionHighlight/MatchTagger.cs
+++ b/SelectionHighlight/MatchTagger.cs
@@ -96,9 +96,13 @@ namespace SelectionHighlight
             {
                 Task.Factory.StartNew(() =>
                 {
-                    var findData =
+                    // By this time the selection might have gone
+                    if (!_selectedWord.IsEmpty)
+                    {
+                        var findData =
                                         new FindData(_selectedWord.GetText(), _selectedWord.Snapshot) { FindOptions = FindOptions.WholeWord };
-                    _glyphsToPlace.AddRange(_textSearchService.FindAll(findData));
+                        _glyphsToPlace.AddRange(_textSearchService.FindAll(findData));
+                    }
                 });
             }
         }


### PR DESCRIPTION
Visual Studio crash diagnostics indicates this extension causes intermittent crashes due to ArgumentOutOfRangeException thrown in FindWordsInDocument. There seems to be a race condition here: by the time the task executes, _selectedWord might have changed and be empty, so FindData constructor would throw  ArgumentOutOfRangeException.